### PR TITLE
Increment and decrement last number only

### DIFF
--- a/src/jquery.cloner.js
+++ b/src/jquery.cloner.js
@@ -241,19 +241,19 @@
                         switch (attr) {
                             case 'value':
                                 var old_val = $(this).val();
-                                var new_val = old_val.replace(/-?\d+/g, function (n) { return ++n; });
+                                var new_val = old_val.replace(/-?(\d+)(?!.*\d)/g, function (n) { return ++n; });
                                 $(this).val(new_val);
                                 break;
 
                             case 'html':
                                 var old_val = $(this).html();
-                                var new_val = old_val.replace(/-?\d+/g, function (n) { return ++n; });
+                                var new_val = old_val.replace(/-?(\d+)(?!.*\d)/g, function (n) { return ++n; });
                                 $(this).html(new_val);
                                 break;
 
                             case 'text':
                                 var old_val = $(this).text();
-                                var new_val = old_val.replace(/-?\d+/g, function (n) { return ++n; });
+                                var new_val = old_val.replace(/-?(\d+)(?!.*\d)/g, function (n) { return ++n; });
                                 $(this).text(new_val);
                                 break;
 
@@ -266,7 +266,7 @@
                                 }
 
                                 var old_val = $(this).attr(attr);
-                                var new_val = old_val.replace(/-?\d+/g, function (n) { return ++n; });
+                                var new_val = old_val.replace(/-?(\d+)(?!.*\d)/g, function (n) { return ++n; });
 
                                 $(this).attr(attr, new_val);
                                 break;
@@ -317,19 +317,19 @@
                         switch (attr) {
                             case 'value':
                                 var old_val = $(this).val();
-                                var new_val = old_val.replace(/-?\d+/g, function (n) { return --n; });
+                                var new_val = old_val.replace(/-?(\d+)(?!.*\d)/g, function (n) { return --n; });
                                 $(this).val(new_val);
                                 break;
 
                             case 'html':
                                 var old_val = $(this).html();
-                                var new_val = old_val.replace(/-?\d+/g, function (n) { return --n; });
+                                var new_val = old_val.replace(/-?(\d+)(?!.*\d)/g, function (n) { return --n; });
                                 $(this).html(new_val);
                                 break;
 
                             case 'text':
                                 var old_val = $(this).text();
-                                var new_val = old_val.replace(/-?\d+/g, function (n) { return --n; });
+                                var new_val = old_val.replace(/-?(\d+)(?!.*\d)/g, function (n) { return --n; });
                                 $(this).text(new_val);
                                 break;
 
@@ -338,7 +338,7 @@
                             case 'class':
                             default:
                                 var old_val = $(this).attr(attr);
-                                var new_val = old_val.replace(/-?\d+/g, function (n) { return --n; });
+                                var new_val = old_val.replace(/-?(\d+)(?!.*\d)/g, function (n) { return --n; });
                                 $(this).attr(new_val);
                                 break;
                         }

--- a/src/jquery.cloner.js
+++ b/src/jquery.cloner.js
@@ -129,6 +129,7 @@
             if (self.options.clearValueOnClone) {
                 $clone.find('input, select').val('');
                 $clone.find('textarea').val('');
+                $clone.find('input, radio').prop('checked', false);
             }
 
             /**

--- a/src/jquery.cloner.js
+++ b/src/jquery.cloner.js
@@ -128,7 +128,7 @@
 
             if (self.options.clearValueOnClone) {
                 $clone.find('input, select').val('');
-                $clone.find('textarea').text('');
+                $clone.find('textarea').val('');
             }
 
             /**


### PR DESCRIPTION
In my opinion, the library incorrectly increments/decrements all numbers:

Example:

``` html
<div class="clonable-block">
  <input id="groups1_attr1" type="text" class="clonable-increment-id">
</div>

```
Result:

``` html
<input id="groups1_attr1" type="text>
<input id="groups2_attr2" type="text>
<input id="groups3_attr3" type="text>
```

My proposition is:

``` html
<input id="groups1_attr1" type="text>
<input id="groups1_attr2" type="text>
<input id="groups1_attr3" type="text>
```
I corrected the code and send the pull request. 

@lienoil Please write what do you think about this.



